### PR TITLE
WFLY8PL-00001: (2.8) EAR with PicketLink dependencies in submodules fail...

### DIFF
--- a/module/src/main/resources/modules/system/layers/base/org/picketlink/core/api/main/module.xml
+++ b/module/src/main/resources/modules/system/layers/base/org/picketlink/core/api/main/module.xml
@@ -35,5 +35,7 @@
         <module name="org.picketlink.common" />
         <module name="org.picketlink.idm.api" export="true" />
         <module name="org.jboss.logging"/>
+        <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.spi"/>
     </dependencies>
 </module>


### PR DESCRIPTION
... due to Weld
